### PR TITLE
Update make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,12 @@ build:
 install:
 	echo "Install Last.Backend, ${OS} version:= ${VERSION}"
 ifeq ($(OS),Linux)
-	mv build/linux/$(NAME_CLI) /usr/local/bin/lb
+	mv build/linux/$(NAME_CLI) /usr/local/bin/$(NAME_CLI)
+	mv build/linux/$(NAME_DAEMON) /usr/local/bin/$(NAME_DAEMON)
 endif
 ifeq ($(OS) ,Darwin)
-	mv build/darwin/$(NAME_CLI) /usr/local/bin/lb
+	mv build/darwin/$(NAME_CLI) /usr/local/bin/$(NAME_CLI)
+	mv build/darwin/$(NAME_DAEMON) /usr/local/bin/$(NAME_DAEMON)
 endif
-	chmod +x /usr/local/bin/$(NAME_CLI)
 
 


### PR DESCRIPTION
This PR updates the make install rule by introducing the following
changes.

- Instead of hard coding the client binary name, we use $(NAME_CLI)

- Install the daemon correctly: The installation was not installing the
daemon. lastbackend executable is installed to /usr/local/bin.

- Remove unnecessary line to make the binary executable, go build takes
care of this.
