### PR TITLE
Interface implemented properly

### DIFF
--- a/pkg/storage/pod.go
+++ b/pkg/storage/pod.go
@@ -21,11 +21,12 @@ package storage
 import (
 	"context"
 	"errors"
-	"github.com/lastbackend/lastbackend/pkg/common/types"
-	"github.com/lastbackend/lastbackend/pkg/storage/store"
 	"regexp"
 	"strings"
+
+	"github.com/lastbackend/lastbackend/pkg/common/types"
 	"github.com/lastbackend/lastbackend/pkg/log"
+	"github.com/lastbackend/lastbackend/pkg/storage/store"
 )
 
 const podStorage = "pods"
@@ -89,7 +90,7 @@ func (s *PodStorage) GetByName(ctx context.Context, app, name string) (*types.Po
 	return pod, nil
 }
 
-func (s *PodStorage) ListByNamespace(ctx context.Context, app string) (map[string]*types.Pod, error) {
+func (s *PodStorage) ListByApp(ctx context.Context, app string) (map[string]*types.Pod, error) {
 
 	log.V(logLevel).Debugf("Storage: Pod: get pods list in app: %s", app)
 


### PR DESCRIPTION
if no service created. lastbackend throws error on restart because `ListByApp` is not implemented. 
```
DEBU[2017-10-15 17:09:04][api] ==> PodController: Get pods in app: sample       
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8d4c22]

goroutine 117 [running]:
github.com/lastbackend/lastbackend/pkg/storage.(*PodStorage).ListByApp(0xc42042a200, 0x1005200, 0xc4200140e0, 0xc4204e69f8, 0x6, 0x1, 0x0, 0x0)
	<autogenerated>:1 +0x32
github.com/lastbackend/lastbackend/pkg/scheduler/pod.(*PodController).Resume(0xc42042af20)
	/root/go/src/github.com/lastbackend/lastbackend/pkg/scheduler/pod/controller.go:112 +0x27b
github.com/lastbackend/lastbackend/pkg/scheduler/runtime.(*Runtime).Loop.func1(0xc4204235c0, 0xc4204264e0)
	/root/go/src/github.com/lastbackend/lastbackend/pkg/scheduler/runtime/runtime.go:85 +0x10b
created by github.com/lastbackend/lastbackend/pkg/scheduler/runtime.(*Runtime).Loop
	/root/go/src/github.com/lastbackend/lastbackend/pkg/scheduler/runtime/runtime.go:73 +0xba
```
steps to reproduce error.
- create an app
- restart the server