### PR TITLE
Update tests in pkg/storage/mock folder

### DIFF
--- a/pkg/storage/mock/ingress_test.go
+++ b/pkg/storage/mock/ingress_test.go
@@ -1,0 +1,735 @@
+//
+// Last.Backend LLC CONFIDENTIAL
+// __________________
+//
+// [2014] - [2018] Last.Backend LLC
+// All Rights Reserved.
+//
+// NOTICE:  All information contained herein is, and remains
+// the property of Last.Backend LLC and its suppliers,
+// if any.  The intellectual and technical concepts contained
+// herein are proprietary to Last.Backend LLC
+// and its suppliers and may be covered by Russian Federation and Foreign Patents,
+// patents in process, and are protected by trade secret or copyright law.
+// Dissemination of this information or reproduction of this material
+// is strictly forbidden unless prior written permission is obtained
+// from Last.Backend LLC.
+//
+
+package mock
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/lastbackend/lastbackend/pkg/distribution/types"
+	"github.com/lastbackend/lastbackend/pkg/storage/storage"
+	"github.com/lastbackend/lastbackend/pkg/storage/store"
+)
+
+func TestIngressStorage_List(t *testing.T) {
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n1  = getIngressAsset("test1", "", true)
+		n2  = getIngressAsset("test2", "", false)
+		nl  = make(map[string]*types.Ingress, 0)
+	)
+
+	nl[n1.Meta.Name] = &n1
+	nl[n2.Meta.Name] = &n2
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx context.Context
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]*types.Ingress
+		wantErr bool
+	}{
+		{
+			"get ingress list success",
+			fields{stg},
+			args{ctx},
+			nl,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.List() storage setup error = %v", err)
+			return
+		}
+
+		for _, n := range nl {
+			if err := stg.Insert(ctx, n); err != nil {
+				t.Errorf("IngressStorage.List() storage setup error = %v", err)
+				return
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.stg.List(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IngressStorage.List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.List() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIngressStorage_Get(t *testing.T) {
+
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n   = getIngressAsset("test", "", true)
+	)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx  context.Context
+		name string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Ingress
+		wantErr bool
+		err     string
+	}{
+		{
+			"get Ingress info failed",
+			fields{stg},
+			args{ctx, "test2"},
+			&n,
+			true,
+			store.ErrEntityNotFound,
+		},
+		{
+			"get Ingress info successful",
+			fields{stg},
+			args{ctx, "test"},
+			&n,
+			false,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.Get() storage setup error = %v", err)
+			return
+		}
+
+		if err := stg.Insert(ctx, &n); err != nil {
+			t.Errorf("IngressStorage.Get() storage setup error = %v", err)
+			return
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := tt.fields.stg.Get(tt.args.ctx, tt.args.name)
+
+			if err != nil {
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.Get() = %v, want %v", err, tt.err)
+					return
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.Get() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.Get() = %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_GetSpec(t *testing.T) {
+
+	var (
+		stg  = newIngressStorage()
+		ctx  = context.Background()
+		n    = getIngressAsset("test", "", true)
+		n1   = getIngressAsset("", "", true)
+		n2   = getIngressAsset("test2", "", true)
+		spec = types.IngressSpec{}
+		rs   = types.RouteSpec{
+			Domain: "domain",
+		}
+	)
+	spec.Routes = make(map[string]types.RouteSpec, 1)
+	spec.Routes[n.Meta.Name] = rs
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx     context.Context
+		ingress *types.Ingress
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.IngressSpec
+		wantErr bool
+		err     string
+	}{
+		{
+			"get Ingress spec failed args invalid",
+			fields{stg},
+			args{ctx, &n1},
+			&spec,
+			true,
+			store.ErrStructArgIsInvalid,
+		},
+		{
+			"get Ingress spec failed not found",
+			fields{stg},
+			args{ctx, &n2},
+			&spec,
+			true,
+			store.ErrEntityNotFound,
+		},
+
+		{
+			"get Ingress spec successful",
+			fields{stg},
+			args{ctx, &n},
+			&spec,
+			false,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.GetSpec() storage setup (clear) error = %v", err)
+			return
+		}
+		if err := stg.Insert(ctx, &n); err != nil {
+			t.Errorf("IngressStorage.GetSpec() storage setup (insert) error = %v", err)
+			return
+		}
+		//add spec info to ingressAsset
+		if err := insertRouteSpec(&n, spec); err != nil {
+			t.Errorf("IngressStorage.GetSpec() storage setup (sub insert) error = %v", err)
+			return
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.stg.GetSpec(tt.args.ctx, tt.args.ingress)
+
+			if err != nil {
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.GetSpec() = %v, want %v", err, tt.err)
+					return
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.GetSpec() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.GetSpec() = %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_Insert(t *testing.T) {
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n1  = getIngressAsset("test", "", true)
+		n2  = getIngressAsset("", "", true)
+	)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx     context.Context
+		ingress *types.Ingress
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Ingress
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful insert",
+			fields{stg},
+			args{ctx, &n1},
+			&n1,
+			false,
+			"",
+		},
+		{
+			"test failed insert: nil structure",
+			fields{stg},
+			args{ctx, nil},
+			&n1,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed insert: invalid structure",
+			fields{stg},
+			args{ctx, &n2},
+			&n1,
+			true,
+			store.ErrStructArgIsInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.Insert() storage setup (clear) error = %v", err)
+			return
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.Insert(tt.args.ctx, tt.args.ingress)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("IngressStorage.Insert() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.Insert() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.Insert() error = %v, want %v", err, tt.err)
+				return
+			}
+
+			//check inserted item
+			got, err := tt.fields.stg.Get(tt.args.ctx, tt.args.ingress.Meta.Name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.Insert() = %v, want %v", got, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_Update(t *testing.T) {
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n1  = getIngressAsset("test1", "", true)
+		n2  = getIngressAsset("test1", "desc", true)
+		n3  = getIngressAsset("test3", "", true)
+
+		nl = make([]*types.Ingress, 0)
+	)
+
+	nl0 := append(nl, &n1)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx     context.Context
+		ingress *types.Ingress
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Ingress
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful update",
+			fields{stg},
+			args{ctx, &n2},
+			&n2,
+			false,
+			"",
+		},
+		{
+			"test failed update: nil structure",
+			fields{stg},
+			args{ctx, nil},
+			&n1,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed update: entity not found",
+			fields{stg},
+			args{ctx, &n3},
+			&n1,
+			true,
+			store.ErrEntityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.Update() storage setup (clear) error = %v", err)
+			return
+		}
+
+		for _, n := range nl0 {
+			if err := stg.Insert(ctx, n); err != nil {
+				t.Errorf("IngressStorage.Update() storage setup (insert) error = %v", err)
+				return
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.Update(tt.args.ctx, tt.args.ingress)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("IngressStorage.Update() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.Update() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.Update() error = %v, want %v", err, tt.err)
+				return
+			}
+
+			//check updated item
+			got, _ := tt.fields.stg.Get(tt.args.ctx, tt.args.ingress.Meta.Name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.Update() = %v, want %v", got, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_SetStatus(t *testing.T) {
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n1  = getIngressAsset("test1", "", true)
+		n2  = getIngressAsset("test1", "", true)
+		n3  = getIngressAsset("test3", "", true)
+
+		nl = make([]*types.Ingress, 0)
+	)
+
+	n2.Status.Ready = false
+
+	nl0 := append(nl, &n1)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx     context.Context
+		ingress *types.Ingress
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Ingress
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful update",
+			fields{stg},
+			args{ctx, &n2},
+			&n2,
+			false,
+			"",
+		},
+		{
+			"test failed update: nil structure",
+			fields{stg},
+			args{ctx, nil},
+			&n1,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed update: entity not found",
+			fields{stg},
+			args{ctx, &n3},
+			&n1,
+			true,
+			store.ErrEntityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.SetStatus() storage setup error = %v", err)
+			return
+		}
+
+		for _, n := range nl0 {
+			if err := stg.Insert(ctx, n); err != nil {
+				t.Errorf("IngressStorage.SetStatus() storage setup error = %v", err)
+				return
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.SetStatus(tt.args.ctx, tt.args.ingress)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("IngressStorage.SetStatus() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.SetStatus() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.SetStatus() error = %v, want %v", err.Error(), tt.err)
+				return
+			}
+
+			got, _ := tt.fields.stg.Get(tt.args.ctx, tt.args.ingress.Meta.Name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IngressStorage.SetStatus()got = %v, want %v", got, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_Remove(t *testing.T) {
+
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+		n1  = getIngressAsset("test1", "", true)
+		n2  = getIngressAsset("test2", "", true)
+	)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+
+	type args struct {
+		ctx     context.Context
+		ingress *types.Ingress
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Ingress
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful ingress remove",
+			fields{stg},
+			args{ctx, &n1},
+			&n2,
+			false,
+			store.ErrEntityNotFound,
+		},
+		{
+			"test failed remove: nil ingress structure",
+			fields{stg},
+			args{ctx, nil},
+			&n2,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed remove: ingress not found",
+			fields{stg},
+			args{ctx, &n2},
+			&n1,
+			true,
+			store.ErrEntityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("IngressStorage.Remove() storage setup (clear) error = %v", err)
+			return
+		}
+
+		if err := stg.Insert(ctx, &n1); err != nil {
+			t.Errorf("IngressStorage.Remove() storage setup (insert) error = %v", err)
+			return
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.Remove(tt.args.ctx, tt.args.ingress)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("IngressStorage.Remove() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("IngressStorage.Remove() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("IngressStorage.Remove() error = %v, want %v", err.Error(), tt.err)
+				return
+			}
+
+			_, err = tt.fields.stg.Get(tt.args.ctx, tt.args.ingress.Meta.Name)
+			if err == nil || tt.err != err.Error() {
+				t.Errorf("IngressStorage.Remove() = %v, want %v", err, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
+func TestIngressStorage_Watch(t *testing.T) {
+
+	var (
+		stg = newIngressStorage()
+		ctx = context.Background()
+	)
+
+	type fields struct {
+		stg storage.Ingress
+	}
+	type args struct {
+		ctx     context.Context
+		ingress chan *types.Ingress
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			"check watch",
+			fields{stg},
+			args{ctx, make(chan *types.Ingress)},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fields.stg.Watch(tt.args.ctx, tt.args.ingress); (err != nil) != tt.wantErr {
+				t.Errorf("IngressStorage.Watch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+//add test routespec into ingress asset
+func insertRouteSpec(ingress *types.Ingress, spec types.IngressSpec) error {
+	ingress.Spec = spec
+	return nil
+}
+
+func getIngressAsset(name, desc string, ready bool) types.Ingress {
+	var n = types.Ingress{
+		Meta: types.IngressMeta{
+			Meta: types.Meta{
+				Name:        name,
+				Description: desc,
+			},
+		},
+		Status: types.IngressStatus{
+			Ready: ready,
+		},
+		Spec: types.IngressSpec{
+			Routes: make(map[string]types.RouteSpec),
+		},
+	}
+
+	/*
+
+
+		var rs = types.RouteSpec{
+			Domain: "domain1",
+		}
+
+			n.Meta.Name = name
+			n.Meta.Description = desc
+			n.Status.Ready = ready
+			n.Spec = make(map[string]*types.RouteSpec)
+	*/
+	//n.Spec.Routes[] = rs
+
+	return n
+}

--- a/pkg/storage/mock/mock_test.go
+++ b/pkg/storage/mock/mock_test.go
@@ -103,6 +103,25 @@ func TestStorage_Node(t *testing.T) {
 	}
 }
 
+func TestStorage_Ingress(t *testing.T) {
+	tests := []struct {
+		name string
+		want storage.Ingress
+	}{
+		{"Ingress storage",
+			newIngressStorage(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := New(); (err != nil) || !reflect.DeepEqual(got.Ingress(), tt.want) {
+				t.Errorf("Storage.Ingress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStorage_Namespace(t *testing.T) {
 	tests := []struct {
 		name string
@@ -193,6 +212,25 @@ func TestStorage_Volume(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got, err := New(); (err != nil) || !reflect.DeepEqual(got.Volume(), tt.want) {
 				t.Errorf("Storage.Volume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStorage_Secret(t *testing.T) {
+	tests := []struct {
+		name string
+		want storage.Secret
+	}{
+		{"Secret storage",
+			newSecretStorage(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := New(); (err != nil) || !reflect.DeepEqual(got.Secret(), tt.want) {
+				t.Errorf("Storage.Secret() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/storage/mock/node_test.go
+++ b/pkg/storage/mock/node_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"encoding/json"
+
 	"github.com/lastbackend/lastbackend/pkg/distribution/types"
 	"github.com/lastbackend/lastbackend/pkg/storage/storage"
 	"github.com/lastbackend/lastbackend/pkg/storage/store"
@@ -1556,7 +1557,7 @@ func TestNodeStorage_Remove(t *testing.T) {
 			store.ErrEntityNotFound,
 		},
 		{
-			"test failed update: nil node structure",
+			"test failed remove: nil node structure",
 			fields{stg},
 			args{ctx, nil},
 			&n2,
@@ -1564,7 +1565,7 @@ func TestNodeStorage_Remove(t *testing.T) {
 			store.ErrStructArgIsNil,
 		},
 		{
-			"test failed update: node not found",
+			"test failed remove: node not found",
 			fields{stg},
 			args{ctx, &n2},
 			&n1,

--- a/pkg/storage/mock/route_test.go
+++ b/pkg/storage/mock/route_test.go
@@ -359,7 +359,7 @@ func TestRouteStorage_Insert(t *testing.T) {
 	for _, tt := range tests {
 
 		if err := stg.Clear(ctx); err != nil {
-			t.Errorf("RouteStorage.ListByNamespace() storage setup error = %v", err)
+			t.Errorf("RouteStorage.Insert() storage setup error = %v", err)
 			return
 		}
 
@@ -494,8 +494,8 @@ func TestRouteStorage_ListSpec(t *testing.T) {
 		ctx = context.Background()
 		n1  = getRouteAsset("ns1", "test1", "")
 		n2  = getRouteAsset("ns1", "test2", "")
-		nl  = make(map[string]*types.Route, 0)
-		ls  = make(map[string]*types.RouteSpec, 0)
+		nl  = make(map[string]*types.Route, 2)
+		ls  = make(map[string]*types.RouteSpec, 2)
 	)
 
 	nl[stg.keyGet(&n1)] = &n1

--- a/pkg/storage/mock/service_test.go
+++ b/pkg/storage/mock/service_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 
 	"context"
+	"reflect"
+
 	"github.com/lastbackend/lastbackend/pkg/distribution/types"
 	"github.com/lastbackend/lastbackend/pkg/storage/storage"
 	"github.com/lastbackend/lastbackend/pkg/storage/store"
-	"reflect"
 )
 
 func TestServiceStorage_Get(t *testing.T) {
@@ -750,6 +751,41 @@ func TestServiceStorage_WatchSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.fields.stg.WatchSpec(tt.args.ctx, tt.args.service); (err != nil) != tt.wantErr {
 				t.Errorf("ServiceStorage.Watch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceStorage_WatchStatus(t *testing.T) {
+	var (
+		stg = newServiceStorage()
+		ctx = context.Background()
+	)
+
+	type fields struct {
+		stg storage.Service
+	}
+	type args struct {
+		ctx     context.Context
+		service chan *types.Service
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			"check watch status",
+			fields{stg},
+			args{ctx, make(chan *types.Service)},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fields.stg.WatchStatus(tt.args.ctx, tt.args.service); (err != nil) != tt.wantErr {
+				t.Errorf("ServiceStorage.WatchStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/storage/mock/trigger_test.go
+++ b/pkg/storage/mock/trigger_test.go
@@ -394,6 +394,212 @@ func TestTriggerStorage_Insert(t *testing.T) {
 	}
 }
 
+func TestTriggerStorage_SetStatus(t *testing.T) {
+	var (
+		ns1 = "ns1"
+		svc = "svc"
+		stg = newTriggerStorage()
+		ctx = context.Background()
+		n1  = getTriggerAsset(ns1, svc, "test1", "")
+		n2  = getTriggerAsset(ns1, svc, "test1", "")
+		n3  = getTriggerAsset(ns1, svc, "test2", "")
+		nl  = make([]*types.Trigger, 0)
+	)
+
+	n2.Status.State = types.StateReady
+
+	nl0 := append(nl, &n1)
+
+	type fields struct {
+		stg storage.Trigger
+	}
+
+	type args struct {
+		ctx     context.Context
+		trigger *types.Trigger
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Trigger
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful update",
+			fields{stg},
+			args{ctx, &n2},
+			&n2,
+			false,
+			"",
+		},
+		{
+			"test failed update: nil structure",
+			fields{stg},
+			args{ctx, nil},
+			&n1,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed update: entity not found",
+			fields{stg},
+			args{ctx, &n3},
+			&n1,
+			true,
+			store.ErrEntityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("TriggerStorage.SetStatus() storage setup error = %v", err)
+			return
+		}
+
+		for _, n := range nl0 {
+			if err := stg.Insert(ctx, n); err != nil {
+				t.Errorf("TriggerStorage.SetStatus() storage setup error = %v", err)
+				return
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.SetStatus(tt.args.ctx, tt.args.trigger)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("TriggerStorage.SetStatus() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("TriggerStorage.SetStatus() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("TriggerStorage.SetStatus() error = %v, want %v", err.Error(), tt.err)
+				return
+			}
+
+			got, _ := tt.fields.stg.Get(tt.args.ctx, ns1, svc, tt.args.trigger.Meta.Name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TriggerStorage.SetStatus() = %v, want %v", got, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
+func TestTriggerStorage_SetSpec(t *testing.T) {
+	var (
+		ns1 = "ns1"
+		svc = "svc"
+		stg = newTriggerStorage()
+		ctx = context.Background()
+		n1  = getTriggerAsset(ns1, svc, "test1", "")
+		n2  = getTriggerAsset(ns1, svc, "test1", "")
+		n3  = getTriggerAsset(ns1, svc, "test2", "")
+		nl  = make([]*types.Trigger, 0)
+	)
+
+	//TODO when TriggerSpec will have data
+	//n2.Spec = types.TriggerSpec{}
+	nl0 := append(nl, &n1)
+
+	type fields struct {
+		stg storage.Trigger
+	}
+
+	type args struct {
+		ctx     context.Context
+		trigger *types.Trigger
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *types.Trigger
+		wantErr bool
+		err     string
+	}{
+		{
+			"test successful update",
+			fields{stg},
+			args{ctx, &n2},
+			&n2,
+			false,
+			"",
+		},
+		{
+			"test failed update: nil structure",
+			fields{stg},
+			args{ctx, nil},
+			&n1,
+			true,
+			store.ErrStructArgIsNil,
+		},
+		{
+			"test failed update: entity not found",
+			fields{stg},
+			args{ctx, &n3},
+			&n1,
+			true,
+			store.ErrEntityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := stg.Clear(ctx); err != nil {
+			t.Errorf("TriggerStorage.SetSpec() storage setup error = %v", err)
+			return
+		}
+
+		for _, n := range nl0 {
+			if err := stg.Insert(ctx, n); err != nil {
+				t.Errorf("TriggerStorage.SetSpec() storage setup error = %v", err)
+				return
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fields.stg.SetSpec(tt.args.ctx, tt.args.trigger)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("TriggerStorage.SetSpec() error = %v, want no error", err.Error())
+					return
+				}
+
+				if tt.wantErr && tt.err != err.Error() {
+					t.Errorf("TriggerStorage.SetSpec() error = %v, want %v", err.Error(), tt.err)
+					return
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("TriggerStorage.SetSpec() error = %v, want %v", err.Error(), tt.err)
+				return
+			}
+
+			got, _ := tt.fields.stg.Get(tt.args.ctx, ns1, svc, tt.args.trigger.Meta.Name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TriggerStorage.SetSpec() = %v, want %v", got, tt.want)
+				return
+			}
+
+		})
+	}
+}
+
 func TestTriggerStorage_Update(t *testing.T) {
 	var (
 		ns1 = "ns1"
@@ -657,6 +863,41 @@ func TestTriggerStorage_WatchSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.fields.stg.WatchSpec(tt.args.ctx, tt.args.trigger); (err != nil) != tt.wantErr {
 				t.Errorf("TriggerStorage.Watch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTriggerStorage_WatchStatus(t *testing.T) {
+	var (
+		stg = newTriggerStorage()
+		ctx = context.Background()
+	)
+
+	type fields struct {
+		stg storage.Trigger
+	}
+	type args struct {
+		ctx     context.Context
+		trigger chan *types.Trigger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			"check watch status",
+			fields{stg},
+			args{ctx, make(chan *types.Trigger)},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fields.stg.WatchStatus(tt.args.ctx, tt.args.trigger); (err != nil) != tt.wantErr {
+				t.Errorf("TriggerStorage.WatchStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
##### Fixes
pkg/storage/mock test coverage 100% except node.go

##### Description
Not all code was covered with tests in the pkg/storage/mock

##### Optional information
in the pkg/storage/mock/node.go:
func (s *NodeStorage) checkRouteArgument(route *types.Route) error
no test for this because does not use anywhere.