### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/pkg/api/client/http/v1/api.go
+++ b/pkg/api/client/http/v1/api.go
@@ -37,7 +37,7 @@ func (ic *ApiClient) List(ctx context.Context) (*vv1.APIList, error) {
 	var i *vv1.APIList
 	var e *errors.Http
 
-	err := ic.client.Get(fmt.Sprintf("/api")).
+	err := ic.client.Get("/api").
 		AddHeader("Content-Type", "application/json").
 		JSON(&i, &e)
 

--- a/pkg/api/client/http/v1/controller.go
+++ b/pkg/api/client/http/v1/controller.go
@@ -37,7 +37,7 @@ func (ic *ControllerClient) List(ctx context.Context) (*vv1.ControllerList, erro
 	var i *vv1.ControllerList
 	var e *errors.Http
 
-	err := ic.client.Get(fmt.Sprintf("/controller")).
+	err := ic.client.Get("/controller").
 		AddHeader("Content-Type", "application/json").
 		JSON(&i, &e)
 

--- a/pkg/api/client/http/v1/discovery.go
+++ b/pkg/api/client/http/v1/discovery.go
@@ -38,7 +38,7 @@ func (ic *DiscoveryClient) List(ctx context.Context) (*vv1.DiscoveryList, error)
 	var i *vv1.DiscoveryList
 	var e *errors.Http
 
-	err := ic.client.Get(fmt.Sprintf("/discovery")).
+	err := ic.client.Get("/discovery").
 		AddHeader("Content-Type", "application/json").
 		JSON(&i, &e)
 

--- a/pkg/api/client/http/v1/exporter.go
+++ b/pkg/api/client/http/v1/exporter.go
@@ -38,7 +38,7 @@ func (ic *ExporterClient) List(ctx context.Context) (*vv1.ExporterList, error) {
 	var i *vv1.ExporterList
 	var e *errors.Http
 
-	err := ic.client.Get(fmt.Sprintf("/exporter")).
+	err := ic.client.Get("/exporter").
 		AddHeader("Content-Type", "application/json").
 		JSON(&i, &e)
 

--- a/pkg/api/client/http/v1/ingress.go
+++ b/pkg/api/client/http/v1/ingress.go
@@ -38,7 +38,7 @@ func (ic *IngressClient) List(ctx context.Context) (*vv1.IngressList, error) {
 	var i *vv1.IngressList
 	var e *errors.Http
 
-	err := ic.client.Get(fmt.Sprintf("/ingress")).
+	err := ic.client.Get("/ingress").
 		AddHeader("Content-Type", "application/json").
 		JSON(&i, &e)
 

--- a/pkg/api/client/http/v1/namespace.go
+++ b/pkg/api/client/http/v1/namespace.go
@@ -131,7 +131,7 @@ func (nc *NamespaceClient) List(ctx context.Context) (*vv1.NamespaceList, error)
 	var s *vv1.NamespaceList
 	var e *errors.Http
 
-	err := nc.client.Get(fmt.Sprintf("/namespace")).
+	err := nc.client.Get("/namespace").
 		AddHeader("Content-Type", "application/json").
 		JSON(&s, &e)
 

--- a/pkg/api/client/http/v1/node.go
+++ b/pkg/api/client/http/v1/node.go
@@ -40,7 +40,7 @@ func (nc NodeClient) List(ctx context.Context) (*vv1.NodeList, error) {
 	var s *vv1.NodeList
 	var e *errors.Http
 
-	err := nc.client.Get(fmt.Sprintf("/cluster/node")).
+	err := nc.client.Get("/cluster/node").
 		AddHeader("Content-Type", "application/json").
 		JSON(&s, &e)
 

--- a/pkg/runtime/cni/utils/iface.go
+++ b/pkg/runtime/cni/utils/iface.go
@@ -61,7 +61,7 @@ func GetDefaultInterface() (*net.Interface, net.IP, error) {
 	}
 
 	if iface == nil {
-		return nil, nil, errors.New(fmt.Sprintf("failed to get default interface"))
+		return nil, nil, errors.New("failed to get default interface")
 	}
 
 	if ifaceAddr == nil {


### PR DESCRIPTION
##### Fixes
[what was fixed by this PR]

##### Description
unnecessary use of fmt.Sprintf

##### Version
[`$ lb version`]

##### Optional information